### PR TITLE
fix: remove Navbar and Footer component in all views

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,23 +2,17 @@
 
 import { Route, Routes } from 'react-router-dom'
 import Chat from './components/Chat/Chat'
-import Footer from './components/Footer'
-import Navbar from './components/Navbar'
 import Home from './pages/Home'
 
 export default function App() {
   return (
     <>
-      <Navbar />
-
       <Routes>
         <Route>
           <Route index element={<Home />} />
           <Route path="/chat" element={<Chat />} />
         </Route>
       </Routes>
-
-      <Footer />
     </>
   )
 }

--- a/frontend/src/pages/Home/index.tsx
+++ b/frontend/src/pages/Home/index.tsx
@@ -1,4 +1,6 @@
 import React from 'react'
+import Footer from '../../components/Footer'
+import Navbar from '../../components/Navbar'
 import About from './components/About'
 import Features from './components/Features'
 import Header from './components/Header'
@@ -6,12 +8,16 @@ import Repository from './components/Repository'
 
 const Home: React.FC = () => {
   return (
-    <main className="container mx-auto px-4">
-      <Header />
-      <Features />
-      <Repository />
-      <About />
-    </main>
+    <>
+      <Navbar />
+      <main className="container mx-auto px-4">
+        <Header />
+        <Features />
+        <Repository />
+        <About />
+      </main>
+      <Footer />
+    </>
   )
 }
 


### PR DESCRIPTION
Se removieron los componentes `<Navbar />` y `<Footer />` para que no se muestren en todas las vistas, especialmente en la vista del chat.

Antes:

![before](https://github.com/user-attachments/assets/6af79539-8b76-4d1d-ae0a-08028cd50d38)

Después:

![after](https://github.com/user-attachments/assets/3df96581-2c20-4ddb-8bd0-00d608ec5659)
